### PR TITLE
[Fix] RGB data corrupt

### DIFF
--- a/launch/k2_client.launch
+++ b/launch/k2_client.launch
@@ -1,5 +1,5 @@
 <launch>
-    <param name="serverNameOrIP" value="172.19.179.123" />
+    <param name="serverNameOrIP" value="192.168.236.1" />
     <group ns="/head/kinect2">
         <param name="rgb_frame" value="/head/kinect2/rgb"/>
         <param name="depth_frame" value="/head/kinect2/depth"/>

--- a/src/startRGB.cpp
+++ b/src/startRGB.cpp
@@ -27,7 +27,7 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
 ***************************************************************************************/
 #include "k2_client/k2_client.h"
 
-int imageSize = 6220800;
+int imageSize = 1920 * 1080 * 4;
 int streamSize = imageSize + sizeof(double);
 std::string cameraName = "rgb";
 std::string imageTopicSubName = "image_color";
@@ -56,12 +56,14 @@ int main(int argC,char **argV)
 
 		mySocket.readData();
         printf("Creating mat.\n");
-        frame = cv::Mat(cv::Size(1920,1080), CV_8UC3, mySocket.mBuffer);
+        frame = cv::Mat(cv::Size(1920, 1080), CV_8UC4, mySocket.mBuffer);
+        cv::cvtColor(frame, frame, CV_BGRA2BGR);
 		cv::flip(frame,frame,1);
         printf("Getting time.\n");
 		double utcTime;
 		memcpy(&utcTime,&mySocket.mBuffer[imageSize],sizeof(double));
         cvImage.header.frame_id = cameraFrame.c_str();
+        printf("%s\n", cameraFrame.c_str());
 		cvImage.encoding = "bgr8";
 		cvImage.image = frame;
 		cvImage.toImageMsg(rosImage);


### PR DESCRIPTION
The new kinect 2 server is sending data using bgra format. The client is however not updated, causing the problem of corrupted rgb data. The pull request fix this issue.